### PR TITLE
Fix custom message input handling and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Build artifacts
+*.o
+*.elf
+*.out
+acorn_comm
+main_mac_x64
+
+# Log files
+*.log
+build.log
+build_errors.log
+acorn_comm.log
+receiver_monitor.log
+serial_devices.log
+
+# Temporary files
+*.tmp
+*.temp
+*~
+.#*
+
+# macOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Linux
+*~
+.fuse_hidden*
+.directory
+.Trash-*
+.nfs*
+
+# Editor backups and temp files
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+*.sublime-*
+
+# Assembly specific
+*.lst
+*.map
+*.sym
+
+# Core dumps
+core
+core.*
+
+# Backup files
+*.bak
+*.backup
+*.old
+
+# Generated files
+src/main_mac_x64.s


### PR DESCRIPTION
## Summary
- Fix option 3 (Send custom message) that was restarting menu instead of processing user input
- Add comprehensive .gitignore file for proper repository hygiene

## Test plan
- [x] Build ARM assembly program successfully
- [x] Verify menu option 3 now accepts and processes custom messages
- [x] Confirm serial transmission with buffer flushing
- [x] Test input validation and error handling
- [x] Verify .gitignore excludes build artifacts and OS files