### PR TITLE
Fix input buffering issue for custom message input

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -554,6 +554,12 @@ get_input_loop:
     cmp r0, #32    @ space
     beq get_input_loop
     
+    @ We have a valid character, now consume the rest of the line
+    @ This prevents the newline from interfering with subsequent input
+    push {r0, lr}
+    bl consume_line
+    pop {r0, lr}
+    
     @ Log input received for valid character
     push {r0}
     ldr r1, =log_input_received
@@ -563,6 +569,33 @@ get_input_loop:
     
     @ Restore link register and return
     pop {lr}
+    bx lr
+
+@ Helper function to consume remaining characters until newline
+consume_line:
+    push {r0, r1, r2, r7, lr}
+consume_line_loop:
+    @ Read one character
+    mov r0, #STDIN
+    ldr r1, =input_buffer
+    add r1, r1, #1    @ Use different part of buffer
+    mov r2, #1
+    mov r7, #SYS_READ
+    swi 0
+    
+    @ Check if we read anything
+    cmp r0, #0
+    ble consume_line_done
+    
+    @ Check if it's a newline
+    ldr r1, =input_buffer
+    add r1, r1, #1
+    ldrb r0, [r1]
+    cmp r0, #10    @ newline
+    bne consume_line_loop
+    
+consume_line_done:
+    pop {r0, r1, r2, r7, lr}
     bx lr
 
 @ Send error handler


### PR DESCRIPTION
## Summary
- Fix critical issue where option 3 (Send custom message) would restart menu instead of prompting for user input
- Add `consume_line` helper function to properly handle stdin buffering after menu selection

## Technical Details
- Menu selection reads single character but leaves newline in buffer
- Custom message input was immediately reading the leftover newline as empty input
- New `consume_line` function clears remaining characters until newline after menu choice
- Preserves existing single-character menu behavior while fixing input conflicts

## Test plan
- [x] Verify menu options 1, 2, 4 continue to work normally
- [x] Test option 3 now properly prompts for custom message input
- [x] Confirm custom messages are transmitted via serial port
- [x] Validate input handling for empty/invalid custom messages