### PR TITLE
Add stdout flush to ensure custom message prompt visibility

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -392,6 +392,11 @@ send_custom:
     mov r7, #SYS_WRITE
     swi 0
     
+    @ Force flush stdout to ensure prompt appears
+    mov r0, #STDOUT
+    mov r7, #SYS_FSYNC
+    swi 0
+    
     @ Read custom message character by character to avoid buffering issues
     ldr r4, =input_buffer    @ Buffer pointer
     mov r5, #0               @ Character count


### PR DESCRIPTION
## Summary
- Add stdout flush after printing custom message prompt to ensure it appears before input reading
- May resolve timing issues where prompt doesn't appear before character-by-character input reading begins

## Technical Details  
- Force flush stdout with `SYS_FSYNC` after writing custom message prompt
- Ensures prompt is immediately visible to user before input collection starts
- Addresses potential buffering issue where prompt might not appear

## Test plan
- [x] Verify custom message prompt appears immediately when option 3 is selected
- [x] Confirm character-by-character input reading works after prompt flush
- [x] Test that other menu options continue to work normally