### PR TITLE
Fix broken custom message input implementation

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -392,18 +392,12 @@ send_custom:
     mov r7, #SYS_WRITE
     swi 0
     
-    @ Read custom message line - simple approach like working Mac version
     @ Force flush stdout to ensure prompt appears
     mov r0, #STDOUT
     mov r7, #SYS_FSYNC
     swi 0
     
-    @ Read custom message character by character to avoid buffering issues
-    ldr r4, =input_buffer    @ Buffer pointer
-    mov r5, #0               @ Character count
-    
-read_custom_loop:
-    @ Read one character
+    @ Read custom message line - simple approach like working Mac version
     mov r0, #STDIN
     ldr r1, =input_buffer
     mov r2, #255


### PR DESCRIPTION
## Summary
- Fix completely broken custom message input in option 3
- Remove hybrid approach that was trying to read 255 characters per "character"
- Implement clean single line reading like working Mac version

## Problem Fixed
The previous code had a broken hybrid approach:
```assembly
@ Read one character  ← Comment said "one character"
mov r2, #255          ← But code tried to read 255 characters\!
```

## Solution
- Clean single `SYS_READ` call to read entire line at once
- Proper newline removal and input validation
- Matches working Mac simulation implementation
- Maintains stdout flush for prompt visibility

## Test plan
- [x] Verified approach works in Mac assembly simulation  
- [x] Test option 3 now properly accepts custom message input on Raspberry Pi
- [x] Confirm other menu options (1, 2, 4) continue to work normally
- [x] Validate custom messages are transmitted via serial port