### PR TITLE
Remove consume_line function causing input buffer conflicts

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -590,11 +590,7 @@ get_input_loop:
     cmp r0, #32    @ space
     beq get_input_loop
     
-    @ We have a valid character, now consume the rest of the line
-    @ This prevents the newline from interfering with subsequent input
-    push {r0, lr}
-    bl consume_line
-    pop {r0, lr}
+    @ No need to consume line - send_custom will handle full line reading
     
     @ Log input received for valid character
     push {r0}
@@ -607,32 +603,6 @@ get_input_loop:
     pop {lr}
     bx lr
 
-@ Helper function to consume remaining characters until newline
-consume_line:
-    push {r0, r1, r2, r7, lr}
-consume_line_loop:
-    @ Read one character
-    mov r0, #STDIN
-    ldr r1, =input_buffer
-    add r1, r1, #1    @ Use different part of buffer
-    mov r2, #1
-    mov r7, #SYS_READ
-    swi 0
-    
-    @ Check if we read anything
-    cmp r0, #0
-    ble consume_line_done
-    
-    @ Check if it's a newline
-    ldr r1, =input_buffer
-    add r1, r1, #1
-    ldrb r0, [r1]
-    cmp r0, #10    @ newline
-    bne consume_line_loop
-    
-consume_line_done:
-    pop {r0, r1, r2, r7, lr}
-    bx lr
 
 @ Send error handler
 send_error:


### PR DESCRIPTION
## Summary
- Fix root cause of option 3 (Send custom message) not working
- Remove `consume_line` function that was causing input buffer conflicts

## Root Cause Analysis
The issue was **NOT** in the `send_custom` function itself, but in buffer conflicts:

1. `get_input` reads menu choice "3" using `input_buffer`
2. `consume_line` was called to eat remaining input, writing to `input_buffer + 1`  
3. `send_custom` tries to read custom message into `input_buffer`
4. **Buffer conflict**: Both functions using same buffer space caused interference

## Solution
- Remove `consume_line` call from `get_input` function
- Remove entire `consume_line` function (no longer needed)
- Let `send_custom` handle full line reading without interference
- Single `input_buffer` now used cleanly by `send_custom` only

## Test plan
- [x] Test option 3 now properly accepts and processes custom message input
- [x] Verify other menu options (1, 2, 4) continue to work normally  
- [x] Confirm no buffer conflicts or input interference
- [x] Validate custom messages are transmitted via serial port