### PR TITLE
Handle leftover newline from menu selection in custom input

### DIFF
--- a/src/main.s
+++ b/src/main.s
@@ -397,13 +397,29 @@ send_custom:
     mov r7, #SYS_FSYNC
     swi 0
     
-    @ Read custom message line - simple approach like working Mac version
+    @ Read line and handle leftover newline from menu selection
     mov r0, #STDIN
     ldr r1, =input_buffer
     mov r2, #255
     mov r7, #SYS_READ
     swi 0
     
+    @ If we got just a newline (length 1), read again for actual input
+    cmp r0, #1
+    bne process_input
+    ldr r1, =input_buffer
+    ldrb r2, [r1]
+    cmp r2, #10    @ newline
+    bne process_input
+    
+    @ That was just the leftover newline, read the actual custom message
+    mov r0, #STDIN
+    ldr r1, =input_buffer
+    mov r2, #255
+    mov r7, #SYS_READ
+    swi 0
+
+process_input:
     @ Check if read was successful
     cmp r0, #0
     ble custom_empty_input


### PR DESCRIPTION
## Summary
- Fix option 3 (Send custom message) by properly handling leftover newline from menu selection
- Implement simple two-read approach to consume leftover input and get actual custom message

## Problem
When user selects option 3 by typing "3\n":
1. `get_input` reads only "3", leaves "\n" in input buffer
2. `send_custom` shows prompt but immediately reads leftover "\n"
3. Treats empty newline as the custom message
4. Shows "Message sent successfully\!" without waiting for user input

## Solution
Simple two-read approach:
1. **First read**: Check if we get just a newline (leftover from menu)
2. **If newline**: Read again to get the actual custom message from user
3. **If not newline**: Process as normal custom message

## Test plan
- [x] Test option 3 now waits for user input after showing prompt
- [x] Verify custom messages are properly read and processed
- [x] Confirm other menu options (1, 2, 4) continue to work normally
- [x] Validate custom messages are transmitted via serial port